### PR TITLE
refactor(Sensei_Teacher): remove teacher login redirect

### DIFF
--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -89,7 +89,7 @@ class Sensei_Teacher {
 		add_filter( 'wp_insert_post_data', array( $this, 'update_lesson_teacher' ), 99, 2 );
 
 		// If a Teacher logs in, redirect to /wp-admin/
-		add_filter( 'wp_login', array( $this, 'teacher_login_redirect' ), 10, 2 );
+		// add_filter( 'wp_login', array( $this, 'teacher_login_redirect' ), 10, 2 );
 
 		add_action( 'admin_menu', array( $this, 'restrict_posts_menu_page' ), 10 );
 		add_filter( 'pre_get_comments', array( $this, 'restrict_comment_moderation' ), 10, 1 );


### PR DESCRIPTION
Doing redirect in `wp_login` breaks flow of 2FA from iThemes Security
when user is supposed to be redirected to URI provided in `redirect_to`
param.

Sensei redirect for teachers should use `login_redirect` filter instead
of intercepting login flow.

https://app.clickup.com/t/27bzb4e

Docs: https://app.clickup.com/2317190/v/dc/26pw6-8023/26pw6-10303