### PR TITLE
refactor(Sensei_Quiz): conditional output JS for action buttons

### DIFF
--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1348,7 +1348,14 @@ class Sensei_Quiz {
 					 <?php esc_html_e( 'Complete quiz', 'sensei-lms' ); ?>
 				 </vaadin-button>
 
-				<?php }?>
+			<?php } ?>
+
+			<?php
+			$action_html = trim( ob_get_clean() );
+
+			if ( $action_html ) {
+				ob_start();
+			?>
 
 				<!--
 					Note: By default, Quiz actions render outside of relevant form `.quiz-questions form`,
@@ -1366,8 +1373,8 @@ class Sensei_Quiz {
 				</script>
 
 			<?php
-
-			$action_html = ob_get_clean();
+			$action_html .= ob_get_clean();
+			}
 
 			add_filter( 'cxl_app_layout_action_bar_actions', static function( array $actions ) use ( $action_html ): array {
 


### PR DESCRIPTION
Do not print custom JS handling buttons click event if there are not buttons to output.

It happens when user passes a quiz. JS was added to `primary` field in Action Bar and prevented displaying any button as primary.

Before
![Screenshot 2023-03-23 at 13 33 38](https://user-images.githubusercontent.com/5165721/227204945-5593701a-5e08-4dc8-babc-1b779d2c6510.png)

After
![Screenshot 2023-03-23 at 13 34 08](https://user-images.githubusercontent.com/5165721/227205044-76f3443a-e60b-4a13-a785-719382ea606d.png)
