### PR TITLE
refactor: allow remove user from lesson with `manage_sensei_grades` cap

### DIFF
--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -459,7 +459,7 @@ class Sensei_Learner_Management {
 		$may_remove_user = false;
 
 		// Only teachers and admins can remove users.
-		if ( current_user_can( 'manage_sensei' ) || get_current_user_id() === $post->post_author ) {
+		if ( current_user_can( 'manage_sensei' ) || current_user_can( 'manage_sensei_grades' ) || get_current_user_id() === $post->post_author ) {
 			$may_remove_user = true;
 		}
 


### PR DESCRIPTION
Background: allow Customer Success Agent role to remove users from lessons as it has `manage_sensei_grades` but not `manage_sensei`.